### PR TITLE
Add logging of Junit 5 tests in the Gradle wrapper console

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,5 +34,8 @@ subprojects {
 
 	test {
 		useJUnitPlatform()
+		testLogging {
+			events = ["passed", "failed", "skipped"]
+		}
 	}
 }


### PR DESCRIPTION
**Goal:** 
Add logging of Junit 5 tests in the Gradle wrapper console

**Expected Behaviour:**
To display logging when running tests via the Gradle Wrapper as in the image below: 
<img width="1635" alt="junit-5-gradlew-tests" src="https://user-images.githubusercontent.com/29547780/119366051-7649ae80-bca8-11eb-8c31-e53a4aa3c740.png">
